### PR TITLE
Various fixes

### DIFF
--- a/asylum.c
+++ b/asylum.c
@@ -176,7 +176,6 @@ int game()
                 scorewipe();
                 plotscore();
                 frameinc = ((options.gearchange == 0) ? 2 : 1);
-                swi_blitz_wait(frameinc);
                 if ((rate50 != 1) && (frameinc < 2)) //rate 25 but one frame passed
                 {
                     swi_blitz_wait(1);
@@ -184,6 +183,7 @@ int game()
                     rate50 = 1;
                 }
                 else if (frameinc > 1) rate50 = 0;
+		swi_next_frame(20);
 
                 framectr += frameinc;
 

--- a/asylum.h
+++ b/asylum.h
@@ -493,6 +493,7 @@ FILE* find_game(int op);
 FILE* find_config(int op);
 int swi_joystick_read(int a, int* x, int* y);
 void swi_blitz_wait(int d);
+void swi_next_frame(int d);
 void swi_blitz_screenflush();
 void swi_fastspr_clearwindow();
 void swi_fastspr_setclipwindow(int x1, int y1, int x2, int y2);

--- a/asylum.h
+++ b/asylum.h
@@ -89,7 +89,7 @@
 const int fullpitch = 0x2155;
 
 typedef struct fastspr_sprite { int x; int y; int w; int h; GLuint t;
-                                int texw; int texh; SDL_Surface* s; } fastspr_sprite;
+                                float texw; float texh; SDL_Surface* s; } fastspr_sprite;
 
 typedef struct board { int first_int; int width; int height;
                        int fourth; int fifth; int sixth; int seventh; int eighth;

--- a/sound.c
+++ b/sound.c
@@ -22,7 +22,7 @@
 
 extern asylum_options options;
 
-char sound_available;
+char sound_available = 1;
 
 void bidforsoundforce(int r0, char r1, char r2, int r3, int r4, int r5, char r6, int r7, Mix_Chunk* chunk)
 {

--- a/vdu.c
+++ b/vdu.c
@@ -839,6 +839,17 @@ void swi_blitz_wait(int d)
     SDL_Delay(d*10);
 }
 
+void swi_next_frame(int d)
+{
+	static int time = SDL_GetTicks();
+	int now = SDL_GetTicks();
+	time += d;
+	if (time > now)
+		SDL_Delay(time - now);
+	else
+		time = now;
+}
+
 void swi_fastspr_clearwindow()
 {
     if (vduvar.opengl)

--- a/vdu.c
+++ b/vdu.c
@@ -93,19 +93,20 @@ void fspplotscaled(fastspr_sprite* sprites, char n, float x, float y,
 	// This rescales as requested ...
 	if ((sprite.w==0) || (sprite.h==0)) return;
 	glBindTexture(GL_TEXTURE_2D, sprite.t);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glEnable(GL_TEXTURE_2D);
 	glEnable(GL_BLEND);
 	glColor4f(1,1,1,1);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glBegin(GL_TRIANGLE_STRIP);
-	glTexCoord2f(0.5/sprite.texw, 0.5/sprite.texh);
-	glVertex3f(posx-0.5*xs, posy-0.5*ys, 0.0);
-	glTexCoord2f((sprite.w+1.5)/sprite.texw, 0.5/sprite.texh);
-	glVertex3f(posx+w+0.5*xs, posy-0.5*ys, 0.0);
-	glTexCoord2f(0.5/sprite.texh, (sprite.h+1.5)/sprite.texh);
-	glVertex3f(posx-0.5*xs, posy+h+0.5*ys, 0.0);
-	glTexCoord2f((sprite.w+1.5)/sprite.texw, (sprite.h+1.5)/sprite.texh);
-	glVertex3f(posx+w+0.5*xs, posy+h+0.5*ys, 0.0);
+	glTexCoord2f(0.0, 0.0);
+	glVertex3f(posx, posy, 0.0);
+	glTexCoord2f(sprite.w/sprite.texw, 0.0);
+	glVertex3f(posx+w, posy, 0.0);
+	glTexCoord2f(0.0, sprite.h/sprite.texh);
+	glVertex3f(posx, posy+h, 0.0);
+	glTexCoord2f(sprite.w/sprite.texw, sprite.h/sprite.texh);
+	glVertex3f(posx+w, posy+h, 0.0);
 	glEnd();
     }
     else
@@ -732,16 +733,15 @@ void decomp(fastspr_sprite* DecompScreen, char* r11)
     DecompScreen->texw = (vduvar.width*8)/5; DecompScreen->texh = vduvar.height*2;
     if (vduvar.opengl)
     {
-        DecompScreen->x = -1;  DecompScreen->y = -1;
         gluBuild2DMipmaps(GL_TEXTURE_2D, GL_RGBA, 512, 512,
 			  GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, (char*)data);
         free(data);
     }
     else
     {
-	DecompScreen->x = 0;  DecompScreen->y = 0;
 	SDL_UnlockSurface(DecompScreen->s);
     }
+    DecompScreen->x = 0;  DecompScreen->y = 0;
 }
 
 void vduread(asylum_options options)
@@ -760,12 +760,12 @@ void vduread(asylum_options options)
     vduvar.strengthw = (_strengthmax>>8); vduvar.strengthh = 6;
     vduvar.bonusx = 290; vduvar.bonusy = 232; vduvar.bonush = 20;
     vduvar.sprw = (16*8)/viewsize; vduvar.sprh = (16*8)/viewsize;
-    SDL_GL_SetAttribute( SDL_GL_RED_SIZE, 5 );
-    SDL_GL_SetAttribute( SDL_GL_GREEN_SIZE, 5 );
-    SDL_GL_SetAttribute( SDL_GL_BLUE_SIZE, 5 );
-    SDL_GL_SetAttribute( SDL_GL_DEPTH_SIZE, 4 );
-    SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 );
-    ArcScreen = SDL_SetVideoMode( vduvar.xreso, vduvar.yreso, 24 /*bpp*/,
+    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 16);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    ArcScreen = SDL_SetVideoMode( vduvar.xreso, vduvar.yreso, 32 /*bpp*/,
                                   (options.opengl ? SDL_OPENGL : 0) |
 				  (options.fullscreen ? SDL_FULLSCREEN : 0));
     if (ArcScreen == NULL)
@@ -964,28 +964,13 @@ int initialize_sprites(char* start, fastspr_sprite* sprites, int max_sprites, ch
             int x = ((0x0fffff00&read_littleendian(q))>>8)%320;
             int y = ((0x0fffff00&read_littleendian(q))>>8)/320;
             if ((y*wid+x < 0) || (y*wid+x >= wid*hei)) printf("%i: x=%i y=%i wid=%i hei=%i: bad idea\n", i, x, y, wid, hei);
-            else if (vduvar.opengl) data[(y+1)*256/*wid*/+(x+1)] = palette[0xff&read_littleendian(q)];
+            else if (vduvar.opengl) data[y*256+x] = palette[0xff&read_littleendian(q)];
             else data[y*wid+x] = palette[0xff&read_littleendian(q)];
         }
 	if (vduvar.opengl)
 	{
-	    //uint32_t neighbours = maze_neighbours[i];
-	    for (int y=1; y<=hei; y++)
-	    {
-		data[y*256] = data[y*256+1]&0xffffff;
-		data[y*256+wid+1] = data[y*256+wid]&0xffffff;
-		/*data[y*256] = alldata[(neighbours&0xff0000)>>16][y*256+wid];
-		  data[y*256+wid+1] = alldata[(neighbours&0xff00)>>8][y*256+1];*/
-	    }
-	    for (int x=0; x<=wid+1; x++)
-	    {
-		data[x] = data[x+256]&0xffffff;
-		data[x+hei*256+256] = data[x+hei*256]&0xffffff;
-		/*data[x] = alldata[(neighbours&0xff000000)>>24][x+hei*256];
-		  data[x+hei*256+256] = alldata[(neighbours&0xff)][x+256];*/
-	    }
 	    //Without this line I don't get textures unless I use gluBuild2DMipmaps
-	    glTexParameteri(GL_TEXTURE_2D,GL_TEXTURE_MIN_FILTER,GL_NEAREST); 
+	    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0,
 			 GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, (char*)data);
 	    free(data);


### PR DESCRIPTION
* 51183eb fixes use of `sound_available` (in `main`) before initialization (in `init_audio`), caused by 78fc1d1e.
* 79218ca makes it run at a fixed speed, as long as the computer is fast enough.
* ef695b2 fixes blurry sprites, as well as flickering screen edge.